### PR TITLE
Run formatter for Vitest setup

### DIFF
--- a/packages/chapplin/package.json
+++ b/packages/chapplin/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"build": "tsc",
 		"check": "tsc --noEmit",
-		"prepare": "pnpm build"
+		"prepare": "pnpm build",
+		"test": "vitest"
 	},
 	"exports": {
 		".": {
@@ -68,6 +69,7 @@
 		"rolldown": "catalog:",
 		"typescript": "catalog:",
 		"vite": "catalog:",
+		"vitest": "catalog:",
 		"zod": "catalog:"
 	},
 	"dependencies": {

--- a/packages/chapplin/test/helpers.test.ts
+++ b/packages/chapplin/test/helpers.test.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+import { applyTools } from "../src/helpers.js";
+
+const createTool =
+	(callback: ReturnType<typeof vi.fn>) =>
+	(server: McpServer): void => {
+		callback(server);
+	};
+
+describe("applyTools", () => {
+	it("invokes each tool with the provided server", () => {
+		const server = {} as McpServer;
+		const firstTool = vi.fn();
+		const secondTool = vi.fn();
+
+		applyTools(server, [createTool(firstTool), createTool(secondTool)]);
+
+		expect(firstTool).toHaveBeenCalledWith(server);
+		expect(secondTool).toHaveBeenCalledWith(server);
+	});
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,6 @@ catalog:
   rolldown: ^1.0.0-beta.51
   typescript: ^5.9.3
   vite: ^7.2.4
+  vitest: ^2.1.5
   zimmerframe: ^1.1.4
   zod: ^3.25.76


### PR DESCRIPTION
## Summary
- apply `pnpm fmt` formatting updates to the chapplin package and Vitest helper test

## Testing
- `pnpm --filter chapplin test -- --runInBand` *(fails: vitest command not found because dependencies could not be installed)*
- `pnpm install --filter chapplin --prefer-offline` *(fails with 403 when fetching @types/estree)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271e93e1ac832a98c4ec302c135b7f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured a testing framework to enable automated test execution and reporting.
  * Added unit tests to verify helper function behavior, improving code reliability and quality assurance.

* **Chores**
  * Added testing tools to the workspace's shared dependency catalog for consistent management and versioning across packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->