### PR TITLE
fix: bump deps

### DIFF
--- a/packages/chapplin/docs/design-fixed.md
+++ b/packages/chapplin/docs/design-fixed.md
@@ -38,7 +38,6 @@ chapplin は Vite ベースのフレームワークで、`tools/`・`resources/`
     "zod": ">=3"
   },
   "dependencies": {
-    "magic-string": "*",
     "vite-plugin-dev-api": "^0.2.1",
     "vite-plugin-singlefile": "*"
   }

--- a/packages/chapplin/docs/design.md
+++ b/packages/chapplin/docs/design.md
@@ -42,7 +42,6 @@ chapplin は、Model Context Protocol (MCP) サーバーと MCP Apps（インタ
     "solid-js": { "optional": true }
   },
   "dependencies": {
-    "magic-string": "*",
     "vite-plugin-dev-api": "^0.2.1",
     "vite-plugin-singlefile": "*"
   }

--- a/packages/chapplin/package.json
+++ b/packages/chapplin/package.json
@@ -94,7 +94,6 @@
 		"@types/react-dom": "catalog:",
 		"@unocss/reset": "catalog:",
 		"hono": "catalog:",
-		"magic-string": "catalog:",
 		"preact": "catalog:",
 		"preact-iso": "^2.11.1",
 		"react": "catalog:",
@@ -104,13 +103,12 @@
 		"typescript": "catalog:",
 		"unocss": "catalog:",
 		"vite": "catalog:",
-		"vite-plugin-dev-api": "^0.2.0",
+		"vite-plugin-dev-api": "^0.2.1",
 		"vite-plugin-singlefile": "catalog:",
 		"vitest": "^4.0.18",
 		"zod": "catalog:"
 	},
 	"dependencies": {
-		"magic-string": "catalog:",
 		"vite-plugin-dev-api": "^0.2.1",
 		"vite-plugin-singlefile": "catalog:"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,11 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@modelcontextprotocol/sdk':
-      specifier: 1.26.0
+      specifier: ^1.23.0
       version: 1.26.0
+    '@types/node':
+      specifier: ^24
+      version: 24.10.13
     '@types/react':
       specifier: 19.2.14
       version: 19.2.14
@@ -27,9 +30,6 @@ catalogs:
     hono:
       specifier: ^4.11.9
       version: 4.11.9
-    magic-string:
-      specifier: ^0.30.21
-      version: 0.30.21
     preact:
       specifier: ^10.28.3
       version: 10.28.3
@@ -384,9 +384,6 @@ importers:
 
   packages/chapplin:
     dependencies:
-      magic-string:
-        specifier: 'catalog:'
-        version: 0.30.21
       vite-plugin-dev-api:
         specifier: ^0.2.1
         version: 0.2.1
@@ -2401,8 +2398,8 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
   cross-env@10.1.0:
@@ -2936,10 +2933,6 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
@@ -5513,7 +5506,7 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
-      cors: 2.8.5
+      cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
@@ -5871,7 +5864,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5880,7 +5873,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
 
   '@types/debug@4.1.12':
     dependencies:
@@ -5896,7 +5889,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -5942,7 +5935,6 @@ snapshots:
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
-    optional: true
 
   '@types/qs@6.14.0': {}
 
@@ -5958,21 +5950,21 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 25.2.3
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       '@types/send': 0.17.6
 
   '@types/unist@2.0.11': {}
@@ -6546,7 +6538,7 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  cors@2.8.5:
+  cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
@@ -7297,10 +7289,6 @@ snapshots:
       '@babel/runtime': 7.28.6
 
   iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -8164,7 +8152,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.0
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,12 @@ packages:
 catalog:
   '@hono/mcp': ^0.2.0
   '@modelcontextprotocol/ext-apps': ^1.0.1
-  '@modelcontextprotocol/sdk': 1.26.0
+  '@modelcontextprotocol/sdk': ^1.23.0
   '@types/node': ^24
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@unocss/reset': ^66.6.0
   hono: ^4.11.9
-  magic-string: ^0.30.21
-  oxc-parser: ^0.101.0
   preact: ^10.28.3
   react: 19.2.4
   react-dom: 19.2.4
@@ -24,5 +22,4 @@ catalog:
   unocss: ^66.6.0
   vite: 7.2.6
   vite-plugin-singlefile: ^2.3.0
-  zimmerframe: ^1.1.4
   zod: ^4.3.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `magic-string` from project dependencies.
  * Updated `vite-plugin-dev-api` to the latest patch version.
  * Adjusted Model Context Protocol SDK catalog version.
  * Cleaned up unused catalog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->